### PR TITLE
Fix invalid DidChangeWatchedFilesRegistrationOptions

### DIFF
--- a/EmmyLua-LS/src/main/kotlin/com/tang/vscode/DidChangeWatchedFilesRegistrationOptions.kt
+++ b/EmmyLua-LS/src/main/kotlin/com/tang/vscode/DidChangeWatchedFilesRegistrationOptions.kt
@@ -1,5 +1,5 @@
 package com.tang.vscode
 
-data class DidChangeWatchedFilesRegistrationOptions(val list: List<FileSystemWatcher>)
+data class DidChangeWatchedFilesRegistrationOptions(val watchers: List<FileSystemWatcher>)
 
-data class FileSystemWatcher(val patter: String)
+data class FileSystemWatcher(val globPattern: String)


### PR DESCRIPTION
Use naming according to the specification:

https://microsoft.github.io/language-server-protocol/specification#didchangewatchedfiles-notification-arrow_right

I'm using [eglot](https://github.com/joaotavora/eglot). `Emacs` raises an error without this commit:

```
Debugger entered--Lisp error: (error "Keyword argument :list not one of (:watchers)")
``` 

Because of an invalid `JSON` message received from the server (`JSON` represented in Emacs data structures here):

```elisp
(:jsonrpc "2.0" :id "1" :method "client/registerCapability" :params
	  (:registrations
	   [(:id "4e5af6ff-5a62-4ca7-bcd7-fb0582cd1c51" :method "workspace/didChangeWatchedFiles" :registerOptions
		 (:list
		  [(:patter "**/*")]))]))
```