### PR TITLE
Fix SignatureHelp block other vscode extension issue

### DIFF
--- a/EmmyLua-LS/src/main/kotlin/com/tang/vscode/LuaTextDocumentService.kt
+++ b/EmmyLua-LS/src/main/kotlin/com/tang/vscode/LuaTextDocumentService.kt
@@ -564,7 +564,9 @@ class LuaTextDocumentService(private val workspace: LuaWorkspaceService) : TextD
                         }
                     }
                 }
-                signatureHelp = SignatureHelp(list, activeSig, activeParameter)
+                if (list.size > 0) {
+                    signatureHelp = SignatureHelp(list, activeSig, activeParameter)
+                }
             }
             signatureHelp
         }


### PR DESCRIPTION
Related PR: https://github.com/EmmyLua/EmmyLua-LanguageServer/pull/31
The `SignatureHelp` should return null if the list is empty, otherwise it will block other extension to show `SignatureHelp`.